### PR TITLE
Added multiple Issue Templates for the Repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: 🐞 Bug Report
+description: Create a bug report about Panache
+title: 'Your Descriptive Title'
+labels: ['bug']
+assignees: alexisbouchez
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please fill out the sections below to help us identify and fix the bug.
+
+              Thank you for taking the time to report this bug.
+
+    - type: checkboxes
+      id: duplicates
+      attributes:
+          # label: Please complete all tasks before submitting a report
+          label: Prerequisites
+          # description: Increase the chances of your issue being accepted by making sure it has not been raised before.
+          options:
+              # - label: I've checked that there is no "open" or "closed" issue about this bug.
+              - label: I [searched for any existing report](https://github.com/PanacheCompany/panache/issues?q=is%3Aissue) about this bug to avoid opening a duplicate.
+                required: true
+              - label: "This issue contains **only one bug**. (hint: make multiple issues/reports, makes it easier on our end!)"
+                required: true
+              - label: The title of this issue **accurately** describes the bug.
+                required: true
+
+    - type: textarea
+      id: description
+      attributes:
+          label: Bug Description
+          description: Please provide a **clear and concise** description of the problem you encountered.
+      validations:
+          required: true
+
+    - type: textarea
+      id: steps
+      attributes:
+          label: Steps to Reproduce
+          #   description: To help me recreate the bug, provide a numbered list of the exact steps taken to trigger the buggy behavior.
+          description: What did you do for the bug to occur?
+          placeholder: |
+              1. Open the web app
+              2. Go to '...'
+              3. Click on '...'
+              4. ...
+
+              If you don't know exact steps, include any relevant details like:
+
+              - What page you were on...
+              - What you were trying to do...
+              - What went wrong...
+      validations:
+          required: true
+
+    - type: textarea
+      attributes:
+          label: Expected Behavior
+          description: Provide a **clear and concise** description of what you expected to happen (or what should have happened).
+      validations:
+          required: true
+
+    - type: textarea
+      attributes:
+          label: Actual Behavior
+          description: "Provide a **clear and concise** description of what *actually* happened."
+      validations:
+          required: true
+
+    - type: input
+      id: browser-version
+      attributes:
+          label: Web Browser name and version
+          placeholder: e.g. "Chrome 133.0.6943.54"
+      validations:
+          required: true
+
+    #- type: input
+    #  id: app-version
+    #  attributes:
+    #      label: Panache version
+    #      placeholder: e.g. "v2.0.2"
+    #  validations:
+    #      required: true
+
+    - type: textarea
+      id: screenshots
+      attributes:
+          label: Screenshots or Videos
+          description: If applicable, attach any relevant screenshots or videos showing the issue.
+      validations:
+          required: false
+
+    - type: textarea
+      id: additional-information
+      attributes:
+          label: Additional Information
+          description: Provide any additional information about this bug.
+      validations:
+          required: false
+
+    - type: markdown
+      attributes:
+          value: |
+              ### Thank you so much for reporting this issue! 🙏 We will investigate and get back to you as soon as possible.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: 💡 Feature Request (Suggestion)
+description: Create a feature request to enhance the experience using Panache.
+title: 'Your Descriptive Title'
+labels: ['enhancement']
+assignees: alexisbouchez
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please fill out the sections below to properly describe the new feature you are suggesting.
+
+              Thank you for taking the time to create this feature request.
+
+    - type: checkboxes
+      id: duplicates
+      attributes:
+          label: Prerequisites
+          description: Increase the chances of your idea being accepted by making sure it has not been raised before.
+          options:
+              - label: I [searched for any existing report](https://github.com/PanacheCompany/panache/labels/enhancement) about this feature to avoid opening a duplicate.
+                required: true
+              - label: "This issue contains **only one feature request**. (hint: make multiple reports, it makes it easier on our end!)"
+                required: true
+              - label: The title of this issue **accurately** describes the bug.
+                required: true
+
+    - type: textarea
+      id: description
+      attributes:
+          label: Feature Request Description
+          description: Provide a clear and concise description of this feature request with any problems and solutions.
+          placeholder: A button in the screen X that allows to do Y
+      validations:
+          required: true
+
+    - type: textarea
+      id: rationale
+      attributes:
+          label: Use Case
+          description: It should be implemented because...? Provide a scenario or use case for this feature, if applicable.
+          placeholder: It will allow to do Y that is needed for Z
+      validations:
+          required: true
+
+    - type: textarea
+      id: screenshots
+      attributes:
+          label: Screenshots or Videos
+          description: Add screenshots or video to help explain this feature request, if applicable.
+      validations:
+          required: false
+
+    - type: textarea
+      id: context
+      attributes:
+          label: Additional context
+          description: Provide any additional information about this feature request.
+      validations:
+          required: false
+
+    - type: markdown
+      attributes:
+          value: |
+              ### Thank you so much for your suggestion! 🙏 Your input helps us improve the app. 🫂

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,35 @@
+name: ❓ Question (Other)
+description: Use this for any other issues!
+title: 'Your Descriptive Title'
+labels: ['question']
+body:
+    - type: checkboxes
+      id: duplicates
+      attributes:
+          label: Prerequisites
+          options:
+              - label: I [searched for any existing reports](https://github.com/PanacheCompany/panache/labels/question) about this question to avoid opening a duplicate.
+                required: true
+              - label: "This issue contains **only one question**. (hint: make multiple issues, it makes it easier on our end!)"
+                required: true
+              - label: The title of this issue **accurately** describes the question.
+                required: true
+
+    - type: textarea
+      attributes:
+          label: What would you like to share/ask?
+          description: Provide a clear and concise explanation of your issue.
+      validations:
+          required: true
+
+    - type: textarea
+      attributes:
+          label: Additional information
+          description: Is there anything else we should know about this issue?
+      validations:
+          required: false
+
+    - type: markdown
+      attributes:
+          value: |
+              ### Thanks for using Panache! 🤝


### PR DESCRIPTION
This change adds 3 GitHub Issue Templates, a Bug Report, a Feature Request, and a plain question one. You can see them in action (they were edited from this) at [the Tidy Tab Groups repo](https://github.com/TidyTabGroups/tidytabgroups/).